### PR TITLE
Fix missing MathJax script

### DIFF
--- a/MkDocs/docs/javascripts/mathjax.js
+++ b/MkDocs/docs/javascripts/mathjax.js
@@ -1,0 +1,13 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$', '$$'], ['\\[', '\\]']]
+  },
+  options: {
+    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise();
+});


### PR DESCRIPTION
## Summary
- add missing `mathjax.js` under MkDocs docs

## Testing
- `python3 -m pip install --user -r requirements.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68878f860b04832eabeb4c73a8662dd9